### PR TITLE
Fix mistake in one of the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ shingles = ks.shingleset_k("abc", k=3)
 ```py
 import kshingle as ks
 shingles = ks.shingleset_range("abc", 2, 3)
-# {'ab', 'abc', 'bc', 'c'}
+# {'ab', 'abc', 'bc'}
 ```
 
 ```py


### PR DESCRIPTION
```
import kshingle as ks
shingles = ks.shingleset_range("abc", 2, 3)
# {'ab', 'abc', 'bc', 'c'}
```

This function does not return 'c' in the resulting set, as it is of size 1. I changed the README to reflect this